### PR TITLE
[build] add support for EFR32 devices on Thread 1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-build
+build*
+output
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-build*
-output
+build*/
+output/
 .idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "openthread-1.1"]
 	path = openthread-1.1
 	url = https://github.com/openthread/openthread.git
+[submodule "ot-efr32"]
+	path = ot-efr32
+	url = https://github.com/openthread/ot-efr32

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,11 @@ FEATURES
 
 CHANGELOG
 ==========
+* 08/18/2021 (commitid:95c5cb793, main)
+    * Add efr32mg12 (brd4166a) support for Thread 1.3 builds
+
+    * Build scripts
+        * Refactor to allow new platforms to be added easily
 
 * 06/15/2021 (commitid:4b36e5115, main)
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ At the root of the repository:
 $ REFERENCE_RELEASE_TYPE=(certification|1.3)  [SD_CARD=/dev/...] [IN_CHINA=(0|1)] ./script/make-reference-release.bash
 ```
 
-This will produce a reference release folder in `./build/`. The folder will be 
+This will produce a reference release folder in `./build/`. The folder will be
 named after the release type, date and the OpenThread commit id.
 
-`SD_CARD` is expected to be the device file path of an SD card inserted to 
-the host. If this variable is specified, the script will flash the Raspberry Pi 
+`SD_CARD` is expected to be the device file path of an SD card inserted to
+the host. If this variable is specified, the script will flash the Raspberry Pi
 image containing OpenThread border router service to the SD card.
 
 If `IN_CHINA` is set to 1, the script will prefer to use apt sources based in
@@ -34,7 +34,7 @@ China so that you can save time while installing software dependencies.
 For example, if you are in China and want to flash the built image to an SD card:
 
 ```
-$ REFERENCE_RELEASE_TYPE=certification IN_CHINA=1 SD_CARD=/dev/sda ./script/make-reference-release.bash 
+$ REFERENCE_RELEASE_TYPE=certification IN_CHINA=1 SD_CARD=/dev/sda ./script/make-reference-release.bash
 ```
 
 When `REFERENCE_RELEASE_TYPE` is `certification`, reference release contains following components:
@@ -50,7 +50,7 @@ When `REFERENCE_RELEASE_TYPE` is `1.3`, reference release contains following com
 - Change log
 - Quick start guide
 
-Note: Currently, only nRF52840 dongles are supported for CLI/RCP firmwares.
+Note: Currently, only nRF52840 dongles and EFR32MG12 BRD4166A boards are supported for CLI/RCP firmwares.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ When `REFERENCE_RELEASE_TYPE` is `1.3`, reference release contains following com
 - Change log
 - Quick start guide
 
-Note: Currently, only nRF52840 dongles and EFR32MG12 BRD4166A boards are supported for CLI/RCP firmwares.
+**Note**: Currently, only the following boards are supported for CLI/RCP firmwares:
+- nRF52840 dongles
+- EFR32MG12 BRD4166A boards
 
 # Contributing
 

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -29,98 +29,286 @@
 
 set -euxo pipefail
 
-echo "OUTPUT_ROOT=${OUTPUT_ROOT?}"
+if [[ -n ${BASH_SOURCE[0]} ]]; then
+    script_path="${BASH_SOURCE[0]}"
+else
+    script_path="$0"
+fi
 
-readonly PLATFORM=nrf52840
+script_dir="$(dirname "$(realpath "$script_path")")"
+repo_dir="$(dirname "$script_dir")"
 
-readonly BUILD_1_2_OPTIONS=('-DOT_BOOTLOADER=USB'
-  '-DOT_REFERENCE_DEVICE=ON'
-  '-DOT_BORDER_ROUTER=ON'
-  '-DOT_SERVICE=ON'
-  '-DOT_COMMISSIONER=ON'
-  '-DOT_JOINER=ON'
-  '-DOT_MAC_FILTER=ON'
-  '-DDHCP6_SERVER=ON'
-  '-DDHCP6_CLIENT=ON'
-  '-DOT_DUA=ON'
-  '-DOT_MLR=ON'
-  '-DOT_CSL_RECEIVER=ON'
-  '-DOT_LINK_METRICS=ON'
-  '-DBORDER_AGENT=OFF'
-  '-DOT_COAP=OFF'
-  '-DOT_COAPS=OFF'
-  '-DOT_ECDSA=OFF'
-  '-DOT_FULL_LOGS=OFF'
-  '-DOT_IP6_FRAGM=OFF'
-  '-DOT_LINK_RAW=OFF'
-  '-DOT_MTD_NETDIAG=OFF'
-  '-DOT_SNTP_CLIENT=OFF'
-  '-DOT_UDP_FORWARD=OFF')
+# Global Vars
+platform=""
+build_dir=""
 
-readonly BUILD_1_1_ENV=(
-  'BORDER_ROUTER=1'
-  'REFERENCE_DEVICE=1'
-  'COMMISSIONER=1'
-  'DHCP6_CLIENT=1'
-  'DHCP6_SERVER=1'
-  'JOINER=1'
-  'MAC_FILTER=1'
-  'BOOTLOADER=1'
-  'USB=1'
+readonly OT_PLATFORMS=(nrf52840 efr32mg12)
+
+readonly build_1_3_options_common=(
+    "-DOT_SRP_SERVER=ON"
+    "-DOT_ECDSA=ON"
+    "-DOT_SERVICE=ON"
+    "-DOT_DNSSD_SERVER=ON"
+    "-DOT_SRP_CLIENT=ON"
 )
 
-NRFUTIL=/tmp/nrfutil-linux
-if [ ! -f $NRFUTIL ]; then
-  wget -O $NRFUTIL https://github.com/NordicSemiconductor/pc-nrfutil/releases/download/v6.1/nrfutil-linux
-  chmod +x $NRFUTIL
-fi
+readonly build_1_3_options_efr32=(
+    ""
+)
 
-if [ ! -f /tmp/private.pem ]; then
-  $NRFUTIL keys generate /tmp/private.pem
-fi
-mkdir -p "$OUTPUT_ROOT"
+readonly build_1_3_options_nrf=(
+    ""
+)
 
-# $1: The basename of the file to zip, e.g. ot-cli-ftd
-# $2: Thread version number, e.g. 1.2
-# $3: The binary path, defaulted as ./build-"$2"/bin/"$1"
-make_zip() {
-  local BINARY_PATH=${3:-"./build-$2/bin/$1"}
-  arm-none-eabi-objcopy -O ihex "$BINARY_PATH" "$1"-"$2".hex
-  $NRFUTIL pkg generate --debug-mode --hw-version 52 --sd-req 0 --application "$1"-"$2".hex --key-file /tmp/private.pem "$1"-"$2".zip
+readonly build_1_2_options_common=(
+    '-DOT_THREAD_VERSION=1.2'
+    '-DOT_REFERENCE_DEVICE=ON'
+    '-DOT_BORDER_ROUTER=ON'
+    '-DOT_SERVICE=ON'
+    '-DOT_COMMISSIONER=ON'
+    '-DOT_JOINER=ON'
+    '-DOT_MAC_FILTER=ON'
+    '-DOT_DHCP6_SERVER=ON'
+    '-DOT_DHCP6_CLIENT=ON'
+    '-DOT_DUA=ON'
+    '-DOT_MLR=ON'
+    '-DOT_LINK_METRICS=ON'
+    '-DOT_BORDER_AGENT=OFF'
+    '-DOT_COAP=OFF'
+    '-DOT_COAPS=OFF'
+    '-DOT_ECDSA=OFF'
+    '-DOT_FULL_LOGS=OFF'
+    '-DOT_IP6_FRAGM=OFF'
+    '-DOT_LINK_RAW=OFF'
+    '-DOT_MTD_NETDIAG=OFF'
+    '-DOT_SNTP_CLIENT=OFF'
+    '-DOT_UDP_FORWARD=OFF'
+)
+
+readonly build_1_2_options_nrf=(
+    '-DOT_BOOTLOADER=USB'
+    '-DOT_CSL_RECEIVER=ON'
+)
+
+readonly build_1_1_env_common=(
+    'BORDER_ROUTER=1'
+    'REFERENCE_DEVICE=1'
+    'COMMISSIONER=1'
+    'DHCP6_CLIENT=1'
+    'DHCP6_SERVER=1'
+    'JOINER=1'
+    'MAC_FILTER=1'
+    'BOOTLOADER=1'
+)
+
+readonly build_1_1_env_nrf=(
+    'USB=1'
+)
+
+# Environment Vars
+# - $thread_version: Thread version number, e.g. 1.2
+# Args
+# - $1: The basename of the file to zip, e.g. ot-cli-ftd
+# - $2: The binary path (optional)
+package()
+{
+    # Parse Args
+    local basename=${1?Please specify app basename}
+    local binary_path=${2:-"${build_dir}/bin/${basename}"}
+    thread_version=${thread_version?}
+
+    # Get build info
+    local commit_id=$(cd "${repo_dir}"/openthread && git rev-parse --short HEAD)
+    local timestamp=$(date +%Y%m%d)
+
+    # Generate .hex file
+    local hex_file="${basename}"-"${thread_version}".hex
+    if [ ! -f "$binary_path" ]; then
+        echo "WARN: $binary_path does not exist. Skipping packaging"
+        return
+    fi
+    arm-none-eabi-objcopy -O ihex "$binary_path" "${hex_file}"
+    arm-none-eabi-objcopy -O ihex "$binary_path" "${hex_file}"
+
+    # Zip
+    local zip_file="${basename}-${thread_version}-${timestamp}-${commit_id}.zip"
+    case "${platform}" in
+        nrf*)
+            $NRFUTIL pkg generate --debug-mode --hw-version 52 --sd-req 0 --application "${hex_file}" --key-file /tmp/private.pem "${zip_file}"
+            ;;
+        *)
+            zip "${zip_file}" "${hex_file}"
+            ;;
+    esac
+
+    # Distribute
+    mv "${zip_file}" "$OUTPUT_ROOT"
 }
 
-if [ "${REFERENCE_RELEASE_TYPE?}" = "certification" ]; then
-  (
-    cd ot-nrf528xx
-    git clean -xfd
-    COMMIT_ID=$(cd ../openthread && git rev-parse --short HEAD)
-    DATE=$(date +%Y%m%d)
-    rm -rf openthread
-    cp -r ../openthread .
-    OT_CMAKE_BUILD_DIR=build-1.2 ./script/build $PLATFORM USB_trans -DOT_THREAD_VERSION=1.2 "${BUILD_1_2_OPTIONS[@]}"
-    make_zip ot-cli-ftd 1.2
-    make_zip ot-rcp 1.2
-    mv ot-cli-ftd-1.2.zip ot-cli-ftd-$DATE-$COMMIT_ID-1.2.zip
-    mv ot-rcp-1.2.zip ot-rcp-$DATE-$COMMIT_ID-1.2.zip
-    mv ./*.zip "$OUTPUT_ROOT"
-    rm -rf openthread
-    git clean -xfd
-    git submodule update --force
-  )
+# Envionment variables:
+# - build_type:             Type of build (optional)
+# - build_script_flags:     Any flags specific to the platform repo's build script (optional)
+# Args:
+# - $1 - thread_version: Thread version number, e.g. 1.2
+# - $2 - platform_repo:  Path to platform's repo, e.g. ot-efr32, ot-nrf528xx
+build()
+{
+    thread_version=${thread_version?}
+    platform_repo=${platform_repo?}
 
-  (
-    cd openthread-1.1
-    COMMIT_ID=$(git rev-parse --short HEAD)
-    DATE=$(date +%Y%m%d)
-    git clean -xfd
-    ./bootstrap
-    make -f examples/Makefile-nrf52840 "${BUILD_1_1_ENV[@]}"
-    make_zip ot-cli-ftd 1.1 output/nrf52840/bin/ot-cli-ftd
-    mv ot-cli-ftd-1.1.zip ot-cli-ftd-$DATE-$COMMIT_ID-1.1.zip
-    mv ./*.zip "$OUTPUT_ROOT"
-    git clean -xfd
-  )
-elif [ "${REFERENCE_RELEASE_TYPE}" = "1.3" ]; then
-  OT_CMAKE_BUILD_DIR=build-1.2 ./script/build $PLATFORM USB_trans -DOT_THREAD_VERSION=1.2
-  make_zip ot-rcp 1.2
-fi
+    mkdir -p "$OUTPUT_ROOT"
+
+    case "${thread_version}" in
+        # Build OpenThread 1.2
+        "1.2")
+            cd ${platform_repo}
+            git clean -xfd
+
+            # Use OpenThread from top-level of repo
+            rm -rf openthread
+            ln -s ../openthread .
+
+            # Build
+            build_dir=${OT_CMAKE_BUILD_DIR:-"${repo_dir}"/build-"${thread_version}"/"${platform}"}
+            OT_CMAKE_BUILD_DIR=${build_dir} ./script/build ${build_script_flags:-} ${platform} ${build_type:-} "$@"
+
+            # Package and distribute
+            local dist_apps=(
+                ot-cli-ftd
+                ot-rcp
+            )
+            for app in ${dist_apps[@]}; do
+                package "${app}"
+            done
+
+            # Clean up
+            rm -rf openthread
+            git clean -xfd
+            git submodule update --force
+            ;;
+
+        # Build OpenThread 1.1
+        "1.1")
+            cd openthread-1.1
+
+            # Prep
+            git clean -xfd
+            ./bootstrap
+
+            # Build
+            make -f examples/Makefile-${platform} "${options[@]}" "$@"
+
+            # Package and distribute
+            local dist_apps=(
+                ot-cli-ftd
+                ot-rcp
+            )
+            for app in ${dist_apps[@]}; do
+                package ${app} ${thread_version} output/${platform}/bin/${app}
+            done
+
+            # Clean up
+            git clean -xfd
+            ;;
+    esac
+
+    cd ${repo_dir}
+}
+
+die() { echo "$*" 1>&2 ; exit 1; }
+
+prebuild_and_build()
+{
+    platform=$1
+    # ==========================================================================
+    # Prebuild
+    # ==========================================================================
+    case "${platform}" in
+        nrf*)
+            # Setup nrfutil
+            if [[ $OSTYPE == "linux"* ]]; then
+                ostype=linux
+            elif [[ $OSTYPE == "darwin"* ]]; then
+                ostype=mac
+            fi
+            NRFUTIL=/tmp/nrfutil-${ostype}
+
+            if [ ! -f $NRFUTIL ]; then
+                wget -O $NRFUTIL https://github.com/NordicSemiconductor/pc-nrfutil/releases/download/v6.1/nrfutil-${ostype}
+                chmod +x $NRFUTIL
+            fi
+
+            # Generate private key
+            if [ ! -f /tmp/private.pem ]; then
+                $NRFUTIL keys generate /tmp/private.pem
+            fi
+            ;;
+    esac
+
+    # ==========================================================================
+    # Build
+    # ==========================================================================
+    if [ "${REFERENCE_RELEASE_TYPE?}" = "certification" ]; then
+        build_1_2_options=("${build_1_2_options_common[@]}")
+        build_1_1_env=("${build_1_1_env_common[@]}")
+
+        case "${platform}" in
+            nrf*)
+                build_1_2_options+=("${build_1_2_options_nrf[@]}")
+                build_1_1_env+=("${build_1_1_env_nrf[@]}")
+                platform_repo=ot-nrf528xx
+
+                thread_version=1.2 build_type="USB_trans" build "${1_2_options[@]}" "$@"
+                thread_version=1.1 build_type="USB_trans" build "${1_1_env[@]}" "$@"
+                ;;
+        esac
+    elif [ "${REFERENCE_RELEASE_TYPE}" = "1.3" ]; then
+        options=("${build_1_3_options_common[@]}")
+
+        case "${platform}" in
+            nrf*)
+                options+=("${build_1_3_options_nrf[@]}")
+                platform_repo=ot-nrf528xx
+
+                thread_version=1.2 build_type="USB_trans" build "${options[@]}" "$@"
+                ;;
+            efr32*)
+                options+=("${build_1_3_options_efr32[@]}")
+                platform_repo=ot-efr32
+
+                thread_version=1.2 build_script_flags="--skip-silabs-apps" build "${options[@]}" "$@"
+                ;;
+        esac
+    else
+        die "Error: REFERENCE_RELEASE_TYPE = ${REFERENCE_RELEASE_TYPE} is unsupported"
+    fi
+}
+
+main()
+{
+    local platforms=()
+
+    if [[ $# == 0 ]]; then
+        platforms=("${OT_PLATFORMS[@]}")
+    else
+        platforms=("$1")
+        shift
+    fi
+
+    # Print OUTPUT_ROOT. Error if OUTPUT_ROOT is not defined
+    OUTPUT_ROOT=$(realpath ${OUTPUT_ROOT?})
+    echo "OUTPUT_ROOT=${OUTPUT_ROOT}"
+    mkdir -p ${OUTPUT_ROOT}
+
+    for p in ${platforms[@]}; do
+        # Check if the platform is supported.
+        echo "${OT_PLATFORMS[@]}" | grep -wq "${p}" || die "ERROR: Unsupported platform: ${p}"
+        printf "\n\n======================================\nBuilding firmware for ${p}\n======================================\n\n"
+        prebuild_and_build ${p}
+    done
+
+}
+
+main "$@"
+
+

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -272,11 +272,11 @@ prebuild_and_build()
 
                 thread_version=1.2 build_type="USB_trans" build "${options[@]}" "$@"
                 ;;
-            efr32*)
+            efr32mg12)
                 options+=("${build_1_3_options_efr32[@]}")
                 platform_repo=ot-efr32
 
-                thread_version=1.2 build_script_flags="--skip-silabs-apps" build "${options[@]}" "$@"
+                thread_version=1.2 build_script_flags="--skip-silabs-apps" build "-DBOARD=brd4166a" "${options[@]}" "$@"
                 ;;
         esac
     else

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -118,8 +118,10 @@ package()
     thread_version=${thread_version?}
 
     # Get build info
-    local commit_id=$(cd "${repo_dir}"/openthread && git rev-parse --short HEAD)
-    local timestamp=$(date +%Y%m%d)
+    local commit_id
+    local timestamp
+    commit_id=$(cd "${repo_dir}"/openthread && git rev-parse --short HEAD)
+    timestamp=$(date +%Y%m%d)
 
     # Generate .hex file
     local hex_file="${basename}"-"${thread_version}".hex
@@ -160,7 +162,7 @@ build()
     case "${thread_version}" in
         # Build OpenThread 1.2
         "1.2")
-            cd ${platform_repo}
+            cd "${platform_repo}"
             git clean -xfd
 
             # Use OpenThread from top-level of repo
@@ -169,14 +171,14 @@ build()
 
             # Build
             build_dir=${OT_CMAKE_BUILD_DIR:-"${repo_dir}"/build-"${thread_version}"/"${platform}"}
-            OT_CMAKE_BUILD_DIR=${build_dir} ./script/build ${build_script_flags:-} ${platform} ${build_type:-} "$@"
+            OT_CMAKE_BUILD_DIR="${build_dir}" ./script/build ${build_script_flags:-} "${platform}" ${build_type:-} "$@"
 
             # Package and distribute
             local dist_apps=(
                 ot-cli-ftd
                 ot-rcp
             )
-            for app in ${dist_apps[@]}; do
+            for app in "${dist_apps[@]}"; do
                 package "${app}"
             done
 
@@ -195,15 +197,15 @@ build()
             ./bootstrap
 
             # Build
-            make -f examples/Makefile-${platform} "${options[@]}" "$@"
+            make -f examples/Makefile-"${platform}" "${options[@]}" "$@"
 
             # Package and distribute
             local dist_apps=(
                 ot-cli-ftd
                 ot-rcp
             )
-            for app in ${dist_apps[@]}; do
-                package ${app} ${thread_version} output/${platform}/bin/${app}
+            for app in "${dist_apps[@]}"; do
+                package "${app}" "${thread_version}" output/"${platform}"/bin/"${app}"
             done
 
             # Clean up
@@ -211,7 +213,7 @@ build()
             ;;
     esac
 
-    cd ${repo_dir}
+    cd "${repo_dir}"
 }
 
 die() { echo "$*" 1>&2 ; exit 1; }
@@ -295,15 +297,15 @@ main()
     fi
 
     # Print OUTPUT_ROOT. Error if OUTPUT_ROOT is not defined
-    OUTPUT_ROOT=$(realpath ${OUTPUT_ROOT?})
+    OUTPUT_ROOT=$(realpath "${OUTPUT_ROOT?}")
     echo "OUTPUT_ROOT=${OUTPUT_ROOT}"
-    mkdir -p ${OUTPUT_ROOT}
+    mkdir -p "${OUTPUT_ROOT}"
 
-    for p in ${platforms[@]}; do
+    for p in "${platforms[@]}"; do
         # Check if the platform is supported.
         echo "${OT_PLATFORMS[@]}" | grep -wq "${p}" || die "ERROR: Unsupported platform: ${p}"
-        printf "\n\n======================================\nBuilding firmware for ${p}\n======================================\n\n"
-        prebuild_and_build ${p}
+        printf "\n\n======================================\nBuilding firmware for %s\n======================================\n\n" "${p}"
+        prebuild_and_build "${p}"
     done
 
 }

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -128,7 +128,6 @@ package()
         return
     fi
     arm-none-eabi-objcopy -O ihex "$binary_path" "${hex_file}"
-    arm-none-eabi-objcopy -O ihex "$binary_path" "${hex_file}"
 
     # Zip
     local zip_file="${basename}-${thread_version}-${timestamp}-${commit_id}.zip"

--- a/script/make-reference-release.bash
+++ b/script/make-reference-release.bash
@@ -57,7 +57,7 @@ main()
     fi
 
     # ==========================================================================
-    # Build raspian
+    # Build raspbian
     # ==========================================================================
     mkdir -p "$OUTPUT_ROOT"
     OUTPUT_ROOT="$OUTPUT_ROOT" ./script/make-raspbian.bash

--- a/script/make-reference-release.bash
+++ b/script/make-reference-release.bash
@@ -39,12 +39,12 @@ main()
     echo "REFERENCE_RELEASE_TYPE=${REFERENCE_RELEASE_TYPE?}"
     mkdir -p build
     OUTPUT_ROOT=$(realpath build/ot-"${REFERENCE_RELEASE_TYPE?}-$(date +%Y%m%d)-$(cd openthread && git rev-parse --short HEAD)")
-    mkdir -p $OUTPUT_ROOT
+    mkdir -p "$OUTPUT_ROOT"
 
     # ==========================================================================
     # Build firmware
     # ==========================================================================
-    for platform in ${OT_PLATFORMS[@]}; do
+    for platform in "${OT_PLATFORMS[@]}"; do
         OUTPUT_ROOT="$OUTPUT_ROOT"/fw_dongle_${platform}/ ./script/make-firmware.bash "${platform}"
     done
 
@@ -52,8 +52,8 @@ main()
     # Build THCI
     # ==========================================================================
     if [ "${REFERENCE_RELEASE_TYPE?}" = "certification" ]; then
-    mkdir -p "$OUTPUT_ROOT"/thci
-    OUTPUT_ROOT="$OUTPUT_ROOT"/thci/ ./script/make-thci.bash
+        mkdir -p "$OUTPUT_ROOT"/thci
+        OUTPUT_ROOT="$OUTPUT_ROOT"/thci/ ./script/make-thci.bash
     fi
 
     # ==========================================================================


### PR DESCRIPTION
This adds support for building efr32 images for Thread 1.3

It also refactors the make-firmware.bash and make-reference-release.bash scripts to allow other platforms to be easily added.

---

# Main changes
- Add ot-efr32 to build script
- Add `ot-efr32` submodule
- Skip Silabs apps in ot-efr32
- Limit efr32 to only brd4166a.
- Refactor `./script/make-firmware.bash`
    - If no platform is specified, the script will build all platforms.
    If a platform is specified as an argument, the script will build
    only that platform

# Other changes
- Allow relative paths for OUTPUT_ROOT when running make-firmware.bash directly
- Add support for downloading nrfutil on MacOS
- Use wildcard to simplify .gitignore