### PR TITLE
[build] add missing qemu-cleanup.sh call

### DIFF
--- a/script/bootstrap.bash
+++ b/script/bootstrap.bash
@@ -63,7 +63,7 @@ install_common_dependencies() {
     coreutils
 }
 
-install_openthread_binraries() {
+install_openthread_binaries() {
   pip3 install -U cmake
   cd third_party/openthread/repo
   mkdir -p build && cd build


### PR DESCRIPTION
This PR fixes a few issues
- Add missing call to `qemu-cleanup.sh`
- Add an exit trap to `make-raspbian.sh` so that the loop devices are always unmounted and detached.
  - Without this, any failure that would cause the script to exit prematurely would leave the raspbian loop device attached.
- Fix a spelling error