### PR TITLE
[ncs] west update call change to narrow

### DIFF
--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -306,7 +306,7 @@ deploy_ncs()
     cd nrf
     git fetch origin
     git reset --hard "$commit_hash" || die "ERROR: unable to checkout the specified sdk-nrf commit."
-    west update
+    west update -n -o=--depth=1
     cd ..
     pip3 install --user -r zephyr/scripts/requirements.txt
     pip3 install --user -r nrf/scripts/requirements.txt


### PR DESCRIPTION
Change "west update" call to narrow and with fetch depth 1. This should speed up update process.

Signed-off-by: Tomasz Kobylarz tomasz.kobylarz@nordicsemi.no