### PR TITLE
Add support for nat64 and trel

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,7 +14,8 @@ FEATURES
 CHANGELOG
 ==========
 * 05/10/2023
-    * TREL and NAT64 are enabled
+    * Added support for REFERENCE_RELEASE_TYPE 1.3.1
+    * TREL and NAT64 are enabled in 1.3.1
     * Updated submodules
         * openthread commitid: 6865b83d7
         * ot-br-posix commitid: d15b080045

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,22 @@ FEATURES
 
 CHANGELOG
 ==========
+* 05/10/2023
+    * TREL and NAT64 are enabled
+    * Updated submodules
+        * openthread commitid: 6865b83d7
+        * ot-br-posix commitid: d15b080045
+        * ot-nrf528xx commitid: e801931
+
+* 01/19/2023
+    * Support for Thread 1.3.0
+    * Updated submodules
+        * openthread commitid: c6179c2
+        * ot-br-posix commitid: 22d4f4e
+        * ot-nrf528xx commitid: e6ee80b
+        * ot-efr32 commitid: 38a4446
+        * ot-commissioner commitid: 8287429
+
 * 08/18/2021 (commitid:95c5cb793, main)
     * Add efr32mg12 (brd4166a) support for Thread 1.3 builds
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ git submodule update --init --recursive
 At the root of the repository:
 
 ```
-$ REFERENCE_PLATFORM=(nrf52840|efr32mg12|ncs|none) REFERENCE_RELEASE_TYPE=(1.2|1.3)  [SD_CARD=/dev/...] [OTBR_RCP_BUS=(UART|SPI)] [IN_CHINA=(0|1)] [OTBR_RADIO_URL='spinel+hdlc+uart:///dev/ttyUSB0'] ./script/make-reference-release.bash
+$ REFERENCE_PLATFORM=(nrf52840|efr32mg12|ncs|none) REFERENCE_RELEASE_TYPE=(1.2|1.3|1.3.1)  [SD_CARD=/dev/...] [OTBR_RCP_BUS=(UART|SPI)] [IN_CHINA=(0|1)] [OTBR_RADIO_URL='spinel+hdlc+uart:///dev/ttyUSB0'] ./script/make-reference-release.bash
 ```
 
 This will produce a reference release folder in `./build/`. The folder will be
@@ -49,7 +49,7 @@ When `REFERENCE_RELEASE_TYPE` is `1.2`, reference release contains following com
 - Change log
 - Quick start guide
 
-When `REFERENCE_RELEASE_TYPE` is `1.3`, reference release contains following components:
+When `REFERENCE_RELEASE_TYPE` is `1.3` or `1.3.1`, reference release contains following components:
 - Raspberry Pi image containing OTBR service with border routing feature, service registry feature and OT Commissioner
 - Firmware
 - Change log

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -275,7 +275,7 @@ build()
                 thread_version=1.1 build_type="USB_trans" build_ot "${build_1_1_env[@]}" "$@"
                 ;;
         esac
-    elif [ "${REFERENCE_RELEASE_TYPE}" = "1.3" ]; then
+    elif [ "${REFERENCE_RELEASE_TYPE}" = "1.3" ] || [ "${REFERENCE_RELEASE_TYPE}" = "1.3.1" ]; then
         options=("${build_1_3_options_common[@]}")
 
         case "${platform}" in

--- a/script/make-raspbian.bash
+++ b/script/make-raspbian.bash
@@ -46,7 +46,7 @@ echo "OTBR_RCP_BUS=${OTBR_RCP_BUS:=UART}"
 echo "REFERENCE_PLATFORM=${REFERENCE_PLATFORM?}"
 echo "OTBR_RADIO_URL=${OTBR_RADIO_URL:=spinel+hdlc+uart:///dev/ttyACM0}"
 
-if [ "$REFERENCE_RELEASE_TYPE" != "1.2" ] && [ "$REFERENCE_RELEASE_TYPE" != "1.3" ]; then
+if [ "$REFERENCE_RELEASE_TYPE" != "1.2" ] && [ "$REFERENCE_RELEASE_TYPE" != "1.3" ] && [ "$REFERENCE_RELEASE_TYPE" != "1.3.1" ]; then
     echo "Invalid reference release type: $REFERENCE_RELEASE_TYPE"
     exit 1
 fi

--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -57,7 +57,7 @@ readonly OTBR_THREAD_1_2_OPTIONS=(
     "-DOT_MLR=ON"
     "-DOTBR_DNSSD_DISCOVERY_PROXY=OFF"
     "-DOTBR_SRP_ADVERTISING_PROXY=OFF"
-    "-DOT_TREL=OFF"
+    "-DOTBR_TREL=OFF"
 )
 
 readonly OTBR_THREAD_1_3_OPTIONS=(
@@ -67,7 +67,22 @@ readonly OTBR_THREAD_1_3_OPTIONS=(
     "-DOT_MLR=ON"
     "-DOTBR_DNSSD_DISCOVERY_PROXY=ON"
     "-DOTBR_SRP_ADVERTISING_PROXY=ON"
-    "-DOT_TREL=ON"
+    "-DOTBR_TREL=OFF"
+    "-DOTBR_NAT64=OFF"
+    "-DOT_BORDER_ROUTING=ON"
+    "-DOT_SRP_CLIENT=ON"
+    "-DOT_DNS_CLIENT=ON"
+)
+
+readonly OTBR_THREAD_1_3_1_OPTIONS=(
+    "-DOT_THREAD_VERSION=1.3.1"
+    "-DOTBR_DUA_ROUTING=ON"
+    "-DOT_DUA=ON"
+    "-DOT_MLR=ON"
+    "-DOTBR_DNSSD_DISCOVERY_PROXY=ON"
+    "-DOTBR_SRP_ADVERTISING_PROXY=ON"
+    "-DOTBR_TREL=ON"
+    "-DOTBR_NAT64=ON"
     "-DOT_BORDER_ROUTING=ON"
     "-DOT_SRP_CLIENT=ON"
     "-DOT_DNS_CLIENT=ON"
@@ -110,9 +125,30 @@ elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.3" ]; then
         efr32mg12)
             readonly LOCAL_OPTIONS=(
                 'BORDER_ROUTING=1'
+                'NAT64=0'
+                'DNS64=0'
+                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]} ${OTBR_COMMON_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100\""
+            )
+            build_options+=("${LOCAL_OPTIONS[@]}")
+            ;;
+        *)
+            readonly LOCAL_OPTIONS=(
+                'BORDER_ROUTING=1'
+                'NAT64=0'
+                'DNS64=0'
+                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]} ${OTBR_COMMON_OPTIONS[@]}\""
+            )
+            build_options+=("${LOCAL_OPTIONS[@]}")
+            ;;
+    esac
+elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.3.1" ]; then
+    case "${REFERENCE_PLATFORM}" in
+        efr32mg12)
+            readonly LOCAL_OPTIONS=(
+                'BORDER_ROUTING=1'
                 'NAT64=1'
                 'DNS64=1'
-                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]} ${OTBR_COMMON_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100\""
+                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_1_OPTIONS[@]} ${OTBR_COMMON_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
@@ -121,7 +157,7 @@ elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.3" ]; then
                 'BORDER_ROUTING=1'
                 'NAT64=1'
                 'DNS64=1'
-                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]} ${OTBR_COMMON_OPTIONS[@]}\""
+                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_1_OPTIONS[@]} ${OTBR_COMMON_OPTIONS[@]}\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;

--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -60,32 +60,28 @@ readonly OTBR_THREAD_1_2_OPTIONS=(
     "-DOTBR_TREL=OFF"
 )
 
-readonly OTBR_THREAD_1_3_OPTIONS=(
-    "-DOT_THREAD_VERSION=1.3"
+readonly OTBR_THREAD_1_3_COMMON_OPTIONS=(
+    ${OTBR_COMMON_OPTIONS[@]}
     "-DOTBR_DUA_ROUTING=ON"
     "-DOT_DUA=ON"
     "-DOT_MLR=ON"
     "-DOTBR_DNSSD_DISCOVERY_PROXY=ON"
     "-DOTBR_SRP_ADVERTISING_PROXY=ON"
-    "-DOTBR_TREL=OFF"
-    "-DOTBR_NAT64=OFF"
     "-DOT_BORDER_ROUTING=ON"
     "-DOT_SRP_CLIENT=ON"
     "-DOT_DNS_CLIENT=ON"
 )
 
+readonly OTBR_THREAD_1_3_OPTIONS=(
+    "-DOT_THREAD_VERSION=1.3"
+    "-DOTBR_TREL=OFF"
+    "-DOTBR_NAT64=OFF"
+)
+
 readonly OTBR_THREAD_1_3_1_OPTIONS=(
     "-DOT_THREAD_VERSION=1.3.1"
-    "-DOTBR_DUA_ROUTING=ON"
-    "-DOT_DUA=ON"
-    "-DOT_MLR=ON"
-    "-DOTBR_DNSSD_DISCOVERY_PROXY=ON"
-    "-DOTBR_SRP_ADVERTISING_PROXY=ON"
     "-DOTBR_TREL=ON"
     "-DOTBR_NAT64=ON"
-    "-DOT_BORDER_ROUTING=ON"
-    "-DOT_SRP_CLIENT=ON"
-    "-DOT_DNS_CLIENT=ON"
 )
 
 build_options=(
@@ -127,7 +123,7 @@ elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.3" ]; then
                 'BORDER_ROUTING=1'
                 'NAT64=0'
                 'DNS64=0'
-                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]} ${OTBR_COMMON_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100\""
+                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]} ${OTBR_THREAD_1_3_COMMON_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
@@ -136,7 +132,7 @@ elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.3" ]; then
                 'BORDER_ROUTING=1'
                 'NAT64=0'
                 'DNS64=0'
-                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]} ${OTBR_COMMON_OPTIONS[@]}\""
+                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]} ${OTBR_THREAD_1_3_COMMON_OPTIONS[@]}\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
@@ -148,7 +144,7 @@ elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.3.1" ]; then
                 'BORDER_ROUTING=1'
                 'NAT64=1'
                 'DNS64=1'
-                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_1_OPTIONS[@]} ${OTBR_COMMON_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100\""
+                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_1_OPTIONS[@]} ${OTBR_THREAD_1_3_COMMON_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
@@ -157,7 +153,7 @@ elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.3.1" ]; then
                 'BORDER_ROUTING=1'
                 'NAT64=1'
                 'DNS64=1'
-                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_1_OPTIONS[@]} ${OTBR_COMMON_OPTIONS[@]}\""
+                "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_1_OPTIONS[@]} ${OTBR_THREAD_1_3_COMMON_OPTIONS[@]}\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;


### PR DESCRIPTION
- Submodules are updated to:

  - openthread: 6865b83d7fd045b1ea7ee3654b5553a29a967f46 (Apr 6)

  - ot-br-posix: d15b080045e96f5515cab7badad3575fa38615a2 (Apr 7)

  - ot-nrf528xx: e801931e10bbb76d5a095921c5861bf1a3830561 (Apr 10)

- Updated mDNSResponder version to 1310.80.1

- Added support for REFERENCE_RELEASE_TYPE 1.3.1
  - TREL and NAT64 are enabled on 1.3.1, and disabled below 1.3.1
  - Some commands to quickly verify TREL in 1.3.1:
    - check trel is enabled: `sudo ot-ctl trel`
     ```
     $ sudo ot-ctl trel
     Enabled
     Done
     ```

    - when connected with another trel enabled device: `sudo ot-ctl trel peers`
     ```
     $ sudo ot-ctl trel peers
     | No  | Ext MAC Address  | Ext PAN Id       | IPv6 Socket Address                              |
     +-----+------------------+------------------+--------------------------------------------------+
     |   1 | 5af76c65bf4ca339 | 0a3a8bac36df2276 | [fd0a:3a8b:ac36:xxxx:xxxx:xxxx:xxxx:xxxx]:36868  |
     Done
     ```

    -  when formed network with another trel enabled device: `sudo ot-ctl multiradio neighbor list`
     ```
     $ sudo ot-ctl multiradio neighbor list
     ExtAddr:5af76c65bf4ca339, RLOC16:0x3c00, Radios:[15.4(255), TREL(255)]
     Done
     ```
  - Some commands to quickly verify NAT64 in 1.3.1:
    - bring up thread network and check nat64 is enabled:
     ```
    $ sudo ot-ctl state
     leader
     Done
    $ sudo ot-ctl nat64 state
     PrefixManager: Active
     Translator: Active
     Done
    ```
 