### PR TITLE
Add option to build OTBR and CLI references separately, and add support for 1.3.x nrf52840 type fw

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,12 +52,12 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: recursive
-      - name: Build full ncs reference release for 1.3
-        run: |
-          export PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH
-          export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-          export GNUARMEMB_TOOLCHAIN_PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/
-          REFERENCE_PLATFORM=ncs REFERENCE_RELEASE_TYPE=1.3 ./script/make-reference-release.bash
+#      - name: Build full ncs reference release for 1.3
+#        run: |
+#          export PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH
+#          export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+#          export GNUARMEMB_TOOLCHAIN_PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/
+#          REFERENCE_PLATFORM=ncs REFERENCE_RELEASE_TYPE=1.3 ./script/make-reference-release.bash
       - name: Build nrf52840 CLI reference release for 1.3.1
         run: |
           export PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Bootstrap
         run: |
           cd /tmp
@@ -48,14 +52,20 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: recursive
-      - name: Build reference release for 1.3
+      - name: Build full ncs reference release for 1.3
         run: |
           export PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH
-          REFERENCE_PLATFORM=nrf52840 REFERENCE_RELEASE_TYPE=1.3  ./script/make-reference-release.bash
+          export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+          export GNUARMEMB_TOOLCHAIN_PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/
+          REFERENCE_PLATFORM=ncs REFERENCE_RELEASE_TYPE=1.3 ./script/make-reference-release.bash
+      - name: Build nrf52840 CLI reference release for 1.3.1
+        run: |
+          export PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH
+          REFERENCE_TYPE=CLI REFERENCE_PLATFORM=nrf52840 REFERENCE_RELEASE_TYPE=1.3.1 ./script/make-reference-release.bash
       - uses: actions/upload-artifact@v3
         with:
           name: reference-releases
           path: |
-            build/ot-1.3*
+            build/*
             retention-days: 1
             if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ $ git submodule update --init --recursive
 At the root of the repository:
 
 ```
-$ REFERENCE_PLATFORM=(nrf52840|efr32mg12|ncs|none) REFERENCE_RELEASE_TYPE=(1.2|1.3|1.3.1)  [SD_CARD=/dev/...] [OTBR_RCP_BUS=(UART|SPI)] [IN_CHINA=(0|1)] [OTBR_RADIO_URL='spinel+hdlc+uart:///dev/ttyUSB0'] ./script/make-reference-release.bash
+$ REFERENCE_PLATFORM=(nrf52840|efr32mg12|ncs|none) REFERENCE_RELEASE_TYPE=(1.2|1.3|1.3.1) [REFERENCE_TYPE=(OTBR|CLI)] [SD_CARD=/dev/...] [OTBR_RCP_BUS=(UART|SPI)] [IN_CHINA=(0|1)] [OTBR_RADIO_URL='spinel+hdlc+uart:///dev/ttyUSB0'] ./script/make-reference-release.bash
 ```
 
 This will produce a reference release folder in `./build/`. The folder will be
-named after the release type, date and the OpenThread commit id.
+named after the release type, date and the OpenThread/ot-br-posix commit id.
 
 `SD_CARD` is expected to be the device file path of an SD card inserted to
 the host. If this variable is specified, the script will flash the Raspberry Pi
@@ -54,6 +54,8 @@ When `REFERENCE_RELEASE_TYPE` is `1.3` or `1.3.1`, reference release contains fo
 - Firmware
 - Change log
 - Quick start guide
+
+With `REFERENCE_TYPE` it's possible to only generate the specified type of reference release. If set to `CLI`, only CLI firmware for hardware type specified by `REFERENCE_PLATFORM` is generated. If set to `OTBR`, only OTBR reference release which contains Raspberry Pi image and a RCP firmware will be generated. If this variable is not specified, all types of reference releases are generated.
 
 **Note**: Currently, only the following boards are supported for CLI/RCP firmwares:
 

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -295,13 +295,13 @@ build()
     elif [ "${REFERENCE_RELEASE_TYPE}" = "1.3" ] || [ "${REFERENCE_RELEASE_TYPE}" = "1.3.1" ]; then
         option_version=${REFERENCE_RELEASE_TYPE//./_}
         option_name_common="build_${option_version}_options_common[@]"
-        options=${!option_name_common}
+        options=(${!option_name_common})
 
         case "${platform}" in
             nrf*)
                 option_name_nrf="build_${option_version}_options_nrf[@]"
                 options_nrf=${!option_name_nrf}
-                options+="${options_nrf[@]}"
+                options+=("${options_nrf[@]}")
                 platform_repo=ot-nrf528xx
 
                 thread_version="${REFERENCE_RELEASE_TYPE}" build_type="USB_trans" build_ot ${options[@]} "$@"
@@ -309,7 +309,7 @@ build()
             efr32mg12)
                 option_name_efr32="build_${option_version}_options_efr32[@]"
                 options_efr32=${!option_name_efr32}
-                options+="${options_efr32[@]}"
+                options+=("${options_efr32[@]}")
                 platform_repo=ot-efr32
                 build_script_flags=("--skip-silabs-apps")
                 thread_version="${REFERENCE_RELEASE_TYPE}" build_ot "-DBOARD=brd4166a" ${options[@]} "$@"

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -312,7 +312,7 @@ build()
                 options+="${options_efr32[@]}"
                 platform_repo=ot-efr32
                 build_script_flags=("--skip-silabs-apps")
-                thread_version=1.2 build_ot "-DBOARD=brd4166a" ${options[@]} "$@"
+                thread_version="${REFERENCE_RELEASE_TYPE}" build_ot "-DBOARD=brd4166a" ${options[@]} "$@"
                 ;;
         esac
     else

--- a/script/make-reference-release.bash
+++ b/script/make-reference-release.bash
@@ -36,29 +36,39 @@ main()
     # ==========================================================================
     echo "REFERENCE_RELEASE_TYPE=${REFERENCE_RELEASE_TYPE?}"
     mkdir -p build
-    OUTPUT_ROOT=$(realpath build/ot-"${REFERENCE_RELEASE_TYPE?}-$(date +%Y%m%d)-$(cd openthread && git rev-parse --short HEAD)")
+    OUTPUT_ROOT=$(realpath build/ot-"${REFERENCE_RELEASE_TYPE?}-$(date +%Y%m%d)-$(cd openthread && git rev-parse --short HEAD)-$(cd ot-br-posix && git rev-parse --short HEAD)")
     mkdir -p "$OUTPUT_ROOT"
+    echo "REFERENCE_TYPE=${REFERENCE_TYPE:=ALL}"
 
-    # ==========================================================================
-    # Build firmware
-    # ==========================================================================
-    if [ "${REFERENCE_PLATFORM}" != "none" ]; then
-        OUTPUT_ROOT="$OUTPUT_ROOT"/fw_dongle_${REFERENCE_PLATFORM}/ ./script/make-firmware.bash "${REFERENCE_PLATFORM}"
+    if [ "${REFERENCE_TYPE}" = "ALL" ] || [ "${REFERENCE_TYPE}" = "CLI" ]; then
+        # ==========================================================================
+        # Build CLI firmware
+        # ==========================================================================
+        OUTPUT_ROOT="$OUTPUT_ROOT"/fw_dongle_${REFERENCE_PLATFORM}/ FW_TYPE="CLI" ./script/make-firmware.bash "${REFERENCE_PLATFORM}"
     fi
 
-    # ==========================================================================
-    # Build THCI
-    # ==========================================================================
-    if [ "${REFERENCE_RELEASE_TYPE?}" = "1.2" ]; then
-        mkdir -p "$OUTPUT_ROOT"/thci
-        OUTPUT_ROOT="$OUTPUT_ROOT"/thci/ ./script/make-thci.bash
-    fi
+    if [ "${REFERENCE_TYPE}" = "ALL" ] || [ "${REFERENCE_TYPE}" = "OTBR" ]; then
+        # ==========================================================================
+        # Build RCP firmware
+        # ==========================================================================
+        if [ "${REFERENCE_PLATFORM}" != "none" ]; then
+            OUTPUT_ROOT="$OUTPUT_ROOT"/fw_dongle_${REFERENCE_PLATFORM}/ FW_TYPE="RCP" ./script/make-firmware.bash "${REFERENCE_PLATFORM}"
+        fi
 
-    # ==========================================================================
-    # Build raspbian
-    # ==========================================================================
-    mkdir -p "$OUTPUT_ROOT"
-    OUTPUT_ROOT="$OUTPUT_ROOT" ./script/make-raspbian.bash
+        # ==========================================================================
+        # Build THCI
+        # ==========================================================================
+        if [ "${REFERENCE_RELEASE_TYPE?}" = "1.2" ]; then
+            mkdir -p "$OUTPUT_ROOT"/thci
+            OUTPUT_ROOT="$OUTPUT_ROOT"/thci/ ./script/make-thci.bash
+        fi
+
+        # ==========================================================================
+        # Build raspbian
+        # ==========================================================================
+        mkdir -p "$OUTPUT_ROOT"
+        OUTPUT_ROOT="$OUTPUT_ROOT" ./script/make-raspbian.bash
+    fi
 
     # ==========================================================================
     # Package docs


### PR DESCRIPTION
This PR introduces the option REFERENCE_TYPE=(OTBR|CLI) so it's possible to build CLI reference release and OTBR(host+RCP) reference release separately. If this option is not provided all types of reference release will be built as before.

ot-br-posix commit id is added to the output path.

Added support for building 1.3.1 reference release with REFERENCE_PLATFORM=nrf52840. It can be used when building OTBR reference release so the same openthread commit is used to build RCP and host. (If we use ncs as platform then the openthread commit is hardcoded in `sdk-nrf` so it may differ with the host image)