### PR TITLE
Remove unnecessary files in GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Bootstrap
         run: |
           cd /tmp


### PR DESCRIPTION
Remove unnecessary files to free up some space. This would help to solve the `System.IO.IOException: No space left on device ` error.