### PR TITLE
[script] refactor `bootstrap` and `make-raspbian.bash`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git_archive_all

--- a/script/make-reference-release.bash
+++ b/script/make-reference-release.bash
@@ -38,6 +38,7 @@ main()
     mkdir -p build
     OUTPUT_ROOT=$(realpath build/ot-"${REFERENCE_RELEASE_TYPE?}-$(date +%Y%m%d)-$(cd openthread && git rev-parse --short HEAD)")
     mkdir -p "$OUTPUT_ROOT"
+    ./script/bootstrap.bash
 
     # ==========================================================================
     # Build firmware

--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -189,7 +189,7 @@ cmake --version
 
 pip3 install zeroconf
 
-su -c "${build_options[*]} script/setup" pi || true
+su -c "${build_options[*]} script/setup" pi
 
 if [ "$REFERENCE_RELEASE_TYPE" = "1.2" ]; then
     cd /home/pi/repo/


### PR DESCRIPTION
### [`script/bootstrap.bash`](https://github.com/openthread/ot-reference-release/pull/67/files#diff-5e645dbf11006c9c2cf9cd5499bea3d2c54893d195f021b5de09d166685b165b)
I think the bootstrap script was originally taken from https://github.com/openthread/ot-br-posix/blob/main/tests/scripts/bootstrap.sh.

Most of the script isn't required since the OTBR build occurs in the mounted Raspberry Pi OS `chroot`, not the host machine. Within the Raspberry Pi OS `chroot`, the OTBR requirements are already being installed in [`script/otbr-setup.bash`](https://github.com/openthread/ot-reference-release/blob/181f96e403c02fdba58bd7209ba03b2064972c26/script/otbr-setup.bash#L178)

This PR removes most of the unnecessary packages and also makes the bootstrap script more flexible, allowing smaller portions of the script to be run via command line arguments

Also, the download of RaspiOS has been moved to [`script/make-raspbian.bash`](https://github.com/openthread/ot-reference-release/pull/67/files#diff-b3db1c4391cab5221ab5ba5feb7fd6391b715c5d59b290d949b4a80845168ff9R94-R113)

### [`script/make-raspbian.bash`](https://github.com/openthread/ot-reference-release/pull/67/files#diff-b3db1c4391cab5221ab5ba5feb7fd6391b715c5d59b290d949b4a80845168ff9)

- `cleanup()` has been refactored
  - Any running processes from `$QEMU_ROOT` are killed before unmounting
- `/etc/resolv.conf` is mounted from the host into `$QEMU_ROOT`. 
  - This is necessary for environments which block public DNS, such as in some corporate networks.
  - The host-machine's DNS configuration is not included in the output raspios image. Instead, the original `/etc/resolv.conf` from the raspios .img will be present in the output image
 