### PR TITLE
Build for 1.3.1 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,16 +53,22 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           submodules: recursive
-      - name: Build reference release for 1.2
+      - name: Build nrf52840 reference release for 1.2
         run: |
           REFERENCE_PLATFORM=nrf52840 REFERENCE_RELEASE_TYPE=1.2  ./script/make-reference-release.bash
-      - name: Build reference release for 1.3
+      - name: Build nrf52840 reference release for 1.3
         run: |
           REFERENCE_PLATFORM=nrf52840 REFERENCE_RELEASE_TYPE=1.3  ./script/make-reference-release.bash
+      - name: Build ncs reference release for 1.3.1
+        run: |
+          git submodule status
+          export ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+          export GNUARMEMB_TOOLCHAIN_PATH=/tmp/gcc-arm-none-eabi-9-2019-q4-major/
+          REFERENCE_PLATFORM=ncs REFERENCE_RELEASE_TYPE=1.3.1 ./script/make-reference-release.bash
       - uses: actions/upload-artifact@v3
         with:
           name: reference-releases
           path: |
-            build/ot-1.3*
+            build/ot-1.3.1*
             retention-days: 1
             if-no-files-found: error

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -181,7 +181,10 @@ build_ot()
 
             # Use OpenThread from top-level of repo
             rm -rf openthread
-            ln -s ../openthread .
+            # git_archive_all doesn't accept symbolic link, so make a copy of openthread and make
+            # it not a submodule
+            cp -r ../openthread .
+            rm openthread/.git
 
             # Build
             build_dir=${OT_CMAKE_BUILD_DIR:-"${repo_dir}"/build-"${thread_version}"/"${platform}"}

--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -82,6 +82,7 @@ readonly OTBR_THREAD_1_3_1_OPTIONS=(
     "-DOT_THREAD_VERSION=1.3.1"
     "-DOTBR_TREL=ON"
     "-DOTBR_NAT64=ON"
+    "-DOTBR_BORDER_ROUTING_DHCP6_PD=ON"
 )
 
 build_options=(
@@ -175,7 +176,7 @@ chown -R pi:pi /home/pi/repo
 cd /home/pi/repo/ot-br-posix
 apt-get update
 apt-get install -y --no-install-recommends git python3-pip
-su -c "${build_options[*]} script/bootstrap" pi
+su -c "DOCKER=1 ${build_options[*]} script/bootstrap" pi
 
 rm -rf /home/pi/repo/ot-br-posix/third_party/openthread/repo
 cp -r /home/pi/repo/openthread /home/pi/repo/ot-br-posix/third_party/openthread/repo


### PR DESCRIPTION
This PR fixes 2 issues:
1. Added DOCKER=1 for otbr bootstrap to skip installing resolvconf.
2. Fix the `expected submodule path 'openthread' not to be a symbolic link` issue caused by make-firmware for nrf52840 creates a symbolic link for openthread submodule. This is not accepted by the git_archive_all tool.

It also adds CI for building 1.3.1 reference release.