### PR TITLE
[script] perserving the permission when cp openthread files

### DIFF
--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -193,7 +193,7 @@ build_ot()
             rm -rf openthread
             # git_archive_all doesn't accept symbolic link, so make a copy of openthread and make
             # it not a submodule
-            cp -r ../openthread .
+            cp -rp ../openthread .
             rm openthread/.git
 
             # Build

--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -191,7 +191,7 @@ apt-get install -y --no-install-recommends git python3-pip
 su -c "DOCKER=1 ${build_options[*]} script/bootstrap" pi
 
 rm -rf /home/pi/repo/ot-br-posix/third_party/openthread/repo
-cp -r /home/pi/repo/openthread /home/pi/repo/ot-br-posix/third_party/openthread/repo
+cp -rp /home/pi/repo/openthread /home/pi/repo/ot-br-posix/third_party/openthread/repo
 
 apt-get purge -y cmake
 pip3 install scikit-build


### PR DESCRIPTION
In some environments, `cp` may produce files which have different permissions from the source files. This can fail the build of OTBR. Hence we need to add `-p` option in the command to preserve the permissions.