### PR TITLE
[script] remove occurrences of python2

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,11 @@ FEATURES
 
 CHANGELOG
 ==========
+* 04/01/2025
+    * Remove the python2 occurrences
+    * Updated submodules
+        * ot-commissioner 06adb26
+
 * 03/05/2025
     * Fix for deprecation of expired DHCPv6 lease prefixes 
     * Updated submodules

--- a/script/make-commissioner.bash
+++ b/script/make-commissioner.bash
@@ -31,10 +31,7 @@ set -euxo pipefail
 
 cd ot-commissioner
 
-wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
-sudo python2 get-pip.py
-
-pip2 install -r tools/commissioner_thci/requirements.txt
+pip3 install -r tools/commissioner_thci/requirements.txt
 ./script/bootstrap.sh || true
 
 mkdir -p build

--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -231,7 +231,8 @@ cmake --version
 pip3 install zeroconf
 
 apt-get install -y --no-install-recommends libgirepository1.0-dev
-pip3 install dbus-python PyGObject
+pip3 install dbus-python==1.3.2
+pip3 install PyGObject
 
 su -c "${build_options[*]} script/setup" pi
 
@@ -244,10 +245,8 @@ fi
 if [ "${REFERENCE_PLATFORM?}" = "ncs" ]; then
     pip3 install -r /home/pi/repo/config/ncs/requirements-nrfutil.txt
     pip3 install --no-dependencies nrfutil==6.0.1
-    wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
-    sudo python2 get-pip.py
     apt-get install -y --no-install-recommends vim wiringpi
-    pip install wrapt==1.12.1
+    pip3 install wrapt==1.12.1
 
     # add calling of link_dongle.py script at startup to update symlink to the dongle
     sed -i '/exit 0/d' /etc/rc.local


### PR DESCRIPTION
We've done the migration from python2 to python3 in ot-commissioner so we should remove all python2 occurrences in the project. 

This PR also fixes the build error caused by latest dbus-python. We're sticking it to an older version.