### PR TITLE
Update ot-commissioner to `f31a98af5`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,10 @@ FEATURES
 
 CHANGELOG
 ==========
+* 05/15/2025
+    * Updated submodules
+        * ot-commissioner commitid: f31a98a
+
 * 04/08/2025
     * Support of RA RDNSS
     * Updated submodules


### PR DESCRIPTION
Includes change to explicitly specify python3 as the python interpreter: https://github.com/openthread/ot-commissioner/pull/315