### PR TITLE
Remove legacy `NETWORK_MANAGER` and `DHCPV6_PD`

### DIFF
--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -102,8 +102,6 @@ build_options=(
     "RELEASE=1"
     "REFERENCE_DEVICE=1"
     "BACKBONE_ROUTER=1"
-    "NETWORK_MANAGER=0"
-    "DHCPV6_PD=0"
     "WEB_GUI=0"
     "REST_API=0"
 )


### PR DESCRIPTION
Update script/otbr-setup.bash as `NETWORK_MANAGER` and `DHCPV6_PD` are removed from `otbr-posix`