### PR TITLE
[pd] enable OT's built-in DHCPv6 PD client

### DIFF
--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -95,6 +95,7 @@ readonly OTBR_THREAD_1_4_OPTIONS=(
     "-DOTBR_TREL=ON"
     "-DOTBR_NAT64=ON"
     "-DOTBR_DHCP6_PD=ON"
+    "-DOT_BORDER_ROUTING_DHCP6_PD_CLIENT=ON"
 )
 
 build_options=(
@@ -176,7 +177,7 @@ elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.4" ]; then
                 'BORDER_ROUTING=1'
                 'NAT64=1'
                 'DNS64=1'
-                'DHCPV6_PD_REF=1'
+                'SYSTEMD_NETWORKD=1'
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_4_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100 -DCMAKE_CXX_FLAGS='-DOPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US=5000'\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
@@ -186,7 +187,7 @@ elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.4" ]; then
                 'BORDER_ROUTING=1'
                 'NAT64=1'
                 'DNS64=1'
-                'DHCPV6_PD_REF=1'
+                'SYSTEMD_NETWORKD=1'
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_4_OPTIONS[@]} -DOT_PLATFORM_BOOTLOADER_MODE=ON\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
@@ -196,7 +197,7 @@ elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.4" ]; then
                 'BORDER_ROUTING=1'
                 'NAT64=1'
                 'DNS64=1'
-                'DHCPV6_PD_REF=1'
+                'SYSTEMD_NETWORKD=1'
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_4_OPTIONS[@]}\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")


### PR DESCRIPTION
The `OT_BORDER_ROUTING_DHCP6_PD_CLIENT=ON` CMake option is now passed during the build of OTBR for the 1.4 release, which enables OT's internal DHCPv6 PD client.
The `SYSTEMD_NETWORKD` configures the build to use `systemd-networkd` as the network tool, with its own DHCPv6 client disabled to avoid conflict with OT's.