### PR TITLE
[script] format shell scripts with make-pretty

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ $ REFERENCE_PLATFORM=nrf52840 REFERENCE_RELEASE_TYPE=1.2 IN_CHINA=1 SD_CARD=/dev
 ```
 
 When `REFERENCE_RELEASE_TYPE` is `1.2`, reference release contains following components:
+
 - Raspberry Pi image containing OTBR service and OT Commissioner
 - Firmware
 - THCI
@@ -52,6 +53,7 @@ When `REFERENCE_RELEASE_TYPE` is `1.2`, reference release contains following com
 - Quick start guide
 
 When `REFERENCE_RELEASE_TYPE` is `1.3` or `1.3.1`, reference release contains following components:
+
 - Raspberry Pi image containing OTBR service with border routing feature, service registry feature and OT Commissioner
 - Firmware
 - Change log

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -184,7 +184,7 @@ build_ot()
     mkdir -p "$OUTPUT_ROOT"
 
     case "${thread_version}" in
-        "1.2"|"1.3"|"1.4")
+        "1.2" | "1.3" | "1.4")
             # Build OpenThread 1.2 or 1.3 or 1.4
             cd "${platform_repo}"
             git clean -xfd

--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -237,7 +237,7 @@ pip3 install PyGObject
 
 su -c "${build_options[*]} script/setup" pi
 
-if [[ "$REFERENCE_RELEASE_TYPE" = "1.2" || "$REFERENCE_RELEASE_TYPE" = "1.3" || "$REFERENCE_RELEASE_TYPE" = "1.4" ]]; then
+if [[ $REFERENCE_RELEASE_TYPE == "1.2" || $REFERENCE_RELEASE_TYPE == "1.3" || $REFERENCE_RELEASE_TYPE == "1.4" ]]; then
     cd /home/pi/repo/
     ./script/make-commissioner.bash
 fi

--- a/script/otbr-setup.bash
+++ b/script/otbr-setup.bash
@@ -110,93 +110,88 @@ build_options=(
 )
 
 if [ "${REFERENCE_RELEASE_TYPE?}" = "1.2" ]; then
+    readonly LOCAL_OPTIONS_COMMON=(
+        'BORDER_ROUTING=0'
+        'NAT64=0'
+        'DNS64=0'
+    )
     case "${REFERENCE_PLATFORM}" in
         efr32mg12)
             readonly LOCAL_OPTIONS=(
-                'BORDER_ROUTING=0'
-                'NAT64=0'
-                'DNS64=0'
+                "${LOCAL_OPTIONS_COMMON[@]}"
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_2_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100 -DCMAKE_CXX_FLAGS='-DOPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US=5000'\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
         ncs)
             readonly LOCAL_OPTIONS=(
-                'BORDER_ROUTING=0'
-                'NAT64=0'
-                'DNS64=0'
+                "${LOCAL_OPTIONS_COMMON[@]}"
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_2_OPTIONS[@]} -DOT_PLATFORM_BOOTLOADER_MODE=ON\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
         *)
             readonly LOCAL_OPTIONS=(
-                'BORDER_ROUTING=0'
-                'NAT64=0'
-                'DNS64=0'
+                "${LOCAL_OPTIONS_COMMON[@]}"
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_2_OPTIONS[@]}\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
     esac
 elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.3" ]; then
+    readonly LOCAL_OPTIONS_COMMON=(
+        'BORDER_ROUTING=1'
+        'NAT64=0'
+        'DNS64=0'
+    )
     case "${REFERENCE_PLATFORM}" in
         efr32mg12)
             readonly LOCAL_OPTIONS=(
-                'BORDER_ROUTING=1'
-                'NAT64=0'
-                'DNS64=0'
+                "${LOCAL_OPTIONS_COMMON[@]}"
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100 -DCMAKE_CXX_FLAGS='-DOPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US=5000'\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
         ncs)
             readonly LOCAL_OPTIONS=(
-                'BORDER_ROUTING=1'
-                'NAT64=0'
-                'DNS64=0'
+                "${LOCAL_OPTIONS_COMMON[@]}"
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]} -DOT_PLATFORM_BOOTLOADER_MODE=ON\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
         *)
             readonly LOCAL_OPTIONS=(
-                'BORDER_ROUTING=1'
-                'NAT64=0'
-                'DNS64=0'
+                "${LOCAL_OPTIONS_COMMON[@]}"
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_3_OPTIONS[@]}\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
     esac
 elif [ "${REFERENCE_RELEASE_TYPE?}" = "1.4" ]; then
+    readonly LOCAL_OPTIONS_COMMON=(
+        'BORDER_ROUTING=1'
+        'NAT64=1'
+        'DNS64=1'
+        'DHCPV6_PD_REF=1'
+    )
     case "${REFERENCE_PLATFORM}" in
         efr32mg12)
             readonly LOCAL_OPTIONS=(
-                'BORDER_ROUTING=1'
-                'NAT64=1'
-                'DNS64=1'
-                'DHCPV6_PD_REF=1'
+                "${LOCAL_OPTIONS_COMMON[@]}"
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_4_OPTIONS[@]} -DOT_RCP_RESTORATION_MAX_COUNT=100 -DCMAKE_CXX_FLAGS='-DOPENTHREAD_CONFIG_MAC_CSL_REQUEST_AHEAD_US=5000'\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
         ncs)
             readonly LOCAL_OPTIONS=(
-                'BORDER_ROUTING=1'
-                'NAT64=1'
-                'DNS64=1'
-                'DHCPV6_PD_REF=1'
+                "${LOCAL_OPTIONS_COMMON[@]}"
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_4_OPTIONS[@]} -DOT_PLATFORM_BOOTLOADER_MODE=ON\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
             ;;
         *)
             readonly LOCAL_OPTIONS=(
-                'BORDER_ROUTING=1'
-                'NAT64=1'
-                'DNS64=1'
-                'DHCPV6_PD_REF=1'
+                "${LOCAL_OPTIONS_COMMON[@]}"
                 "OTBR_OPTIONS=\"${OTBR_THREAD_1_4_OPTIONS[@]}\""
             )
             build_options+=("${LOCAL_OPTIONS[@]}")
@@ -237,10 +232,12 @@ pip3 install PyGObject
 
 su -c "${build_options[*]} script/setup" pi
 
-if [[ $REFERENCE_RELEASE_TYPE == "1.2" || $REFERENCE_RELEASE_TYPE == "1.3" || $REFERENCE_RELEASE_TYPE == "1.4" ]]; then
-    cd /home/pi/repo/
-    ./script/make-commissioner.bash
-fi
+case "$REFERENCE_RELEASE_TYPE" in
+    "1.2" | "1.3" | "1.4")
+        cd /home/pi/repo/
+        ./script/make-commissioner.bash
+        ;;
+esac
 
 # nRF Connect SDK related actions
 if [ "${REFERENCE_PLATFORM?}" = "ncs" ]; then


### PR DESCRIPTION
This change formats shell scripts in the repository by running `script/make-pretty shell`.

This uses `shfmt` to enforce a consistent style across all shell scripts. This is a style-only change with no functional impact.
