### PR TITLE
Bump ot-commissioner to fix python path variable typo in CMakeLists.txt‎

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,11 @@ FEATURES
 
 CHANGELOG
 ==========
+* 03/11/2026
+    * Fix python path variable typo in ot-commissioner CMakeLists
+    * Updated submodules
+        * ot-commissioner commitid: 03f4bef
+
 * 03/03/2026
     * Updated submodules
         * openthread commitid: cf1d23c


### PR DESCRIPTION
`ot-commissioner 03f4bef397b5be3dc5d1666ebb5b400b9616a2ab`

Include the https://github.com/openthread/ot-commissioner/pull/347 to fix python path variable typo in CMakeLists.txt‎.